### PR TITLE
Add second plugin to e2e test

### DIFF
--- a/actual_tests/e2e_tests/test_basic_plugin.py
+++ b/actual_tests/e2e_tests/test_basic_plugin.py
@@ -126,7 +126,11 @@ def test_new_plugin_e2e(tmp_path_factory):
             assert passed >= 65
             assert skipped >= 6
 
-    # Uninstall plugin.
+    # Remove plugin, and test another one.
+    # This is much faster than having a completely separate test. We lose some test
+    # independence, but the speedup is worthwhile.
+
+    # Uninstall previous plugin.
     cmd = f'uv pip uninstall --python {path_to_python} dsd-newfly'
     cmd_parts = shlex.split(cmd)
     subprocess.run(cmd_parts)


### PR DESCRIPTION
After testing the first plugin in e2e test, uninstall it and build a second plugin with a space in the platform name, just like integration tests. Coupled to test of first plugin, but much more efficient than a separate test.