### PR TITLE
docs: update README instructions to use generate_plugin.py instead of configure_plugin.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ Usage notes
 ---
 
 - Clone (or download) this repo.
-- Run `python configure_plugin.py`, and answer the small set of prompts:
+- Run `python generate_plugin.py`, and answer the small set of prompts:
 
 ```sh
-$ python configure_plugin.py 
+$ python generate_plugin.py 
 What platform are you targeting? (Example: Fly.io) CodeRed
 What's the name of your plugin package? (Example: dsd-flyio) dsd-codered
 Will your plugin support the --automate-all CLI arg? (yes/no) yes


### PR DESCRIPTION
The usage notes now reference generate_plugin.py instead of the outdated configure_plugin.py script, ensuring the documentation reflects the current workflow and avoids confusion for users following the setup instructions.