### PR TITLE
fix(generate_plugin.py): instantiate PluginConfig object when assigning to plugin_config

### DIFF
--- a/generate_plugin.py
+++ b/generate_plugin.py
@@ -23,7 +23,7 @@ def generate_plugin(plugin_config, args):
 if __name__ == "__main__":
     # Parse cli, get required info, and generate plugin.
     args = cli.parse_cli()
-    plugin_config = PluginConfig
+    plugin_config = PluginConfig()
     generator_utils.get_plugin_info(plugin_config)
 
     generate_plugin(plugin_config, args)


### PR DESCRIPTION
The code was incorrectly assigning the class PluginConfig itself instead of creating an instance. Instantiating PluginConfig with parentheses fixes the error and ensures that plugin_config is a proper object for further processing in the script.