### PR TITLE
Clean up handling of target_dir

### DIFF
--- a/generate_plugin.py
+++ b/generate_plugin.py
@@ -24,6 +24,6 @@ if __name__ == "__main__":
     # Parse cli, get required info, and generate plugin.
     args = cli.parse_cli()
     plugin_config = PluginConfig()
-    generator_utils.get_plugin_info(plugin_config)
+    generator_utils.get_plugin_info(args, plugin_config)
 
     generate_plugin(plugin_config, args)

--- a/utils/generator_utils.py
+++ b/utils/generator_utils.py
@@ -29,6 +29,19 @@ def get_plugin_info(plugin_config):
         msg = "What name do you want to appear in the LICENSE file? "
         plugin_config.license_name = input(msg)
 
+        path_root = Path(__file__).parents[1]
+        default_target_dir = path_root.parent
+        msg = "Where do you want to write the new plugin? "
+        msg += f"\n  Default location: {default_target_dir.as_posix()}"
+        msg += "\n(Press Enter to accept default location, or specify a different location.)"
+        msg += "\n"
+        target_dir_response = input(msg)
+        if not target_dir_response:
+            plugin_config.target_dir = default_target_dir
+        else:
+            plugin_config.target_dir = Path(target_dir_response)
+        breakpoint()
+
         # Review responses.
         msg = "\nHere's the information you've provided:"
         print(msg)
@@ -36,6 +49,7 @@ def get_plugin_info(plugin_config):
         print(f"  Package name: {plugin_config.pkg_name}")
         print(f"  Supports --automate-all: {plugin_config.support_automate_all}")
         print(f"  Name on license: {plugin_config.license_name}")
+        print(f"  Path for new plugin: {plugin_config.target_dir}")
 
         msg = "\nIs this information correct? (yes/no) "
         response = input(msg)

--- a/utils/generator_utils.py
+++ b/utils/generator_utils.py
@@ -5,7 +5,7 @@ import sys
 import shutil
 
 
-def get_plugin_info(plugin_config):
+def get_plugin_info(args, plugin_config):
     """Prompts user for all the info needed to generate a new plugin."""
     while True:
         msg = "What platform are you targeting? (Example: Fly.io) "

--- a/utils/generator_utils.py
+++ b/utils/generator_utils.py
@@ -36,15 +36,27 @@ def get_plugin_info(args, plugin_config):
         # Path to new plugin
         path_root = Path(__file__).parents[1]
         default_target_dir = path_root.parent
-        msg = "Where do you want to write the new plugin? "
-        msg += f"\n  Default location: {default_target_dir.as_posix()}"
-        msg += "\n(Press Enter to accept default location, or specify a different location.)"
-        msg += "\n"
-        target_dir_response = input(msg)
-        if not target_dir_response:
-            plugin_config.target_dir = default_target_dir
+
+        if not args.target_dir:
+            msg = "Where do you want to write the new plugin? "
+            msg += f"\n  Default location: {default_target_dir.as_posix()}"
+            msg += "\n(Press Enter to accept default location, or specify a different location.)"
+            msg += "\n"
+            target_dir_response = input(msg)
+            if not target_dir_response:
+                plugin_config.target_dir = default_target_dir
+            else:
+                plugin_config.target_dir = Path(target_dir_response)
         else:
-            plugin_config.target_dir = Path(target_dir_response)
+            # args.target_dir is primarily for testing, but someone may use it directly.
+            msg = "Is this where you want to write the new plugin? {args.target_dir}"
+            msg += "\n(Press Enter to use this location, or specify a different location.)"
+            msg += "\n"
+            target_dir_response = input(msg)
+            if not target_dir_response:
+                plugin_config.target_dir = args.target_dir
+            else:
+                plugin_config.target_dir = Path(target_dir_response)
 
         # Review responses.
         msg = "\nHere's the information you've provided:"

--- a/utils/generator_utils.py
+++ b/utils/generator_utils.py
@@ -45,7 +45,6 @@ def get_plugin_info(args, plugin_config):
             plugin_config.target_dir = default_target_dir
         else:
             plugin_config.target_dir = Path(target_dir_response)
-        breakpoint()
 
         # Review responses.
         msg = "\nHere's the information you've provided:"

--- a/utils/generator_utils.py
+++ b/utils/generator_utils.py
@@ -49,7 +49,7 @@ def get_plugin_info(args, plugin_config):
                 plugin_config.target_dir = Path(target_dir_response)
         else:
             # args.target_dir is primarily for testing, but someone may use it directly.
-            msg = "Is this where you want to write the new plugin? {args.target_dir}"
+            msg = f"\nIs this where you want to write the new plugin? {args.target_dir}"
             msg += "\n(Press Enter to use this location, or specify a different location.)"
             msg += "\n"
             target_dir_response = input(msg)

--- a/utils/generator_utils.py
+++ b/utils/generator_utils.py
@@ -8,9 +8,11 @@ import shutil
 def get_plugin_info(args, plugin_config):
     """Prompts user for all the info needed to generate a new plugin."""
     while True:
+        # Platform
         msg = "What platform are you targeting? (Example: Fly.io) "
         plugin_config.platform_name = input(msg)
 
+        # Plugin package name
         msg = "What's the name of your plugin package? (Example: dsd-flyio) "
         while True:
             plugin_config.pkg_name = input(msg)
@@ -19,6 +21,7 @@ def get_plugin_info(args, plugin_config):
             else:
                 print("The package name must start with `dsd-`.")
 
+        # --automate-all support
         msg = "Will your plugin support the --automate-all CLI arg? (yes/no) "
         response = input(msg)
         if response.lower() in ("yes", "y"):
@@ -26,9 +29,11 @@ def get_plugin_info(args, plugin_config):
         else:
             plugin_config.support_automate_all = False
 
+        # LICENSE name
         msg = "What name do you want to appear in the LICENSE file? "
         plugin_config.license_name = input(msg)
 
+        # Path to new plugin
         path_root = Path(__file__).parents[1]
         default_target_dir = path_root.parent
         msg = "Where do you want to write the new plugin? "
@@ -54,7 +59,7 @@ def get_plugin_info(args, plugin_config):
         msg = "\nIs this information correct? (yes/no) "
         response = input(msg)
         if response.lower() in ("yes", "y"):
-            break
+            return
 
         msg = "Sorry, please try again.\n\n"
         print(msg)

--- a/utils/plugin_config.py
+++ b/utils/plugin_config.py
@@ -10,6 +10,7 @@ class PluginConfig:
     pkg_name: str = ""
     support_automate_all: bool = False
     license_name: str = ""
+    target_dir: Path = ""
 
     def validate(self):
         """Validate the plugin config."""


### PR DESCRIPTION
The `--target-dir` flag is primarily used for testing, with a non-interactive workflow. This PR handles the case where a user passes `--target-dir` in the interactive workflow.